### PR TITLE
Remove fdopen

### DIFF
--- a/zlib/zutil.h
+++ b/zlib/zutil.h
@@ -130,17 +130,8 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if defined(MACOS)
 #  define OS_CODE  7
-#  ifndef Z_SOLO
-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
-#      include <unix.h> /* for fdopen */
-#    else
-#      ifndef fdopen
-#        define fdopen(fd,mode) NULL /* No fdopen() */
-#      endif
-#    endif
-#  endif
 #endif
 
 #ifdef __acorn

--- a/zlib/zutil.h
+++ b/zlib/zutil.h
@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS)
+#if defined(MACOS) || defined(TARGET_OS_MAC)
 #  define OS_CODE  7
 #endif
 


### PR DESCRIPTION
Cherry pick commit https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9

As the description says, fdopen is no longer used. "No longer" also includes the version used by gcc 1.2.11

I can compile zlib now

fixes #21 